### PR TITLE
Merge feature/create-png-output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 v1/lib/external/vendor
 .idea
+png

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 v1/lib/external/vendor
 .idea
-png
+v1/tmp

--- a/v1/lib/output/consoleoutput.php
+++ b/v1/lib/output/consoleoutput.php
@@ -6,7 +6,7 @@
  * @author Max Späth <max.spaeth@cn-consult.eu>
  */
 
-require_once __DIR__.'/../baseoutput.php';
+require_once __DIR__ . '/../baseoutput.php';
 
 /**
  * This class inherits from the BaseOutput class, so we need to implement the output() function here, which will print every game cycle the complete gamefield on a console.
@@ -30,9 +30,9 @@ class ConsoleOutput extends BaseOutput
         for ($cycle = 0; $cycle<$numCycles; $cycle++)
         { // Amount of cycles
             for($i=0; $i<$y; $i++)
-            { // Make columns
+            { // Make rows
                 for($j=0; $j<$x; $j++)
-                { // Make rows
+                { // Make columns
                     if ($gameFieldController->getGameField()->getCellByCoords($j,$i)->isAlive()) echo "1";
                     else echo "0";
                 }

--- a/v1/lib/output/pngoutput.php
+++ b/v1/lib/output/pngoutput.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * @version 0.1
+ * @copyright 2016 CN-Consult GmbH
+ * @author Max Späth <max.spaeth@cn-consult.eu>
+ */
+
+require_once __DIR__."/../pngcreator.php";
+require_once __DIR__."/../baseoutput.php";
+
+class PngOutput extends BaseOutput
+{
+    /**
+     * This function needs to be implemented in every plugin which extends from this class.
+     * It gets the necessary parameters to output the gamefield.
+     *
+     * @param GameFieldController $_gameFieldController The gamefieldcontroller which contains the gamefield.
+     * @param int $_numCycles The amount of rounds the game should be played.
+     */
+    public function output(GameFieldController $_gameFieldController, $_numCycles)
+    {
+        $pngCreator = new PngCreator;
+
+        $pngCreator->createPng($_gameFieldController, $_numCycles);
+    }
+}

--- a/v1/lib/output/pngoutput.php
+++ b/v1/lib/output/pngoutput.php
@@ -10,11 +10,14 @@
 require_once __DIR__."/../pngcreator.php";
 require_once __DIR__."/../baseoutput.php";
 
+/**
+ * This class inherits from the BaseOutput class, so we need to implement the output() function here, which will save the gamefield every cylce as png file.
+ */
 class PngOutput extends BaseOutput
 {
     /**
-     * This function needs to be implemented in every plugin which extends from this class.
-     * It gets the necessary parameters to output the gamefield.
+     * This function is extended from the baseoutput class.
+     * It creates and saves the gamefield each cycle as png file to /v1/tmp/png.
      *
      * @param GameFieldController $_gameFieldController The gamefieldcontroller which contains the gamefield.
      * @param int $_numCycles The amount of rounds the game should be played.
@@ -23,6 +26,10 @@ class PngOutput extends BaseOutput
     {
         $pngCreator = new PngCreator;
 
-        $pngCreator->createPng($_gameFieldController, $_numCycles);
+        for ($cycle = 0; $cycle<$_numCycles; $cycle++)
+        { // Amount of cycles
+            $pngCreator->createPng($_gameFieldController->getGameField(),$cycle);
+            $_gameFieldController->run();
+        }
     }
 }

--- a/v1/lib/output/pngoutput.php
+++ b/v1/lib/output/pngoutput.php
@@ -27,7 +27,7 @@ class PngOutput extends BaseOutput
         $pngCreator = new PngCreator;
 
         for ($cycle = 0; $cycle<$_numCycles; $cycle++)
-        { // Amount of cycles
+        { // Creates a png for each cycle.
             $pngCreator->createPng($_gameFieldController->getGameField(),$cycle);
             $_gameFieldController->run();
         }

--- a/v1/lib/pngcreator.php
+++ b/v1/lib/pngcreator.php
@@ -14,6 +14,7 @@ class pngCreator
 {
     /**
      * Creates the png and saves it to lib/output/png.
+     *
      * @param GameFieldController $_gameFieldController The GameFieldController for calculating alive states of all cells for each round.
      * @param int $_numCycles Amount of rounds the game should be played.
      */
@@ -24,24 +25,27 @@ class pngCreator
         $x = $gameFieldController->getGameField()->getWidth();
         $y = $gameFieldController->getGameField()->getHeight();
 
-        for ($cycle = 0; $cycle<$numCycles; $cycle++)
+        for($cycle = 0; $cycle<$numCycles; $cycle++)
         { // Amount of cycles
             $fieldPng = imagecreate($x*10,$y*10);
             imagecolorallocate($fieldPng, 243, 243, 243);
             imagesetthickness($fieldPng, 5);
-            
+
             for($i=0; $i<$y; $i++)
             { // Make columns
                 for($j=0; $j<$x; $j++)
                 { // Make rows
-                    $x1 = $j*10-2;
-                    $x2 = $x1+10-2;
-                    $y1 = $i*10-2;
-                    $y2 = $y1+10-2;
-                    imagefilledrectangle($fieldPng , $x1 , $y1 , $x2 , $y2 , 25 );
+                    if($gameFieldController->getGameField()->getCellByCoords($j,$i)->isAlive() == true)
+                    {
+                        $x1 = $j * 10 - 2;
+                        $x2 = $x1 + 10 - 2;
+                        $y1 = $i * 10 - 2;
+                        $y2 = $y1 + 10 - 2;
+                        imagefilledrectangle($fieldPng, $x1, $y1, $x2, $y2, 25);
+                    }
                 }
             }
-            imagepng($fieldPng,__DIR__."/png/cycle".$numCycles.".png");
+            imagepng($fieldPng,__DIR__."/output/png/cycle".$cycle.".png");
             imagedestroy($fieldPng);
             $gameFieldController->run();
         }

--- a/v1/lib/pngcreator.php
+++ b/v1/lib/pngcreator.php
@@ -15,39 +15,34 @@ class pngCreator
     /**
      * Creates the png and saves it to lib/output/png.
      *
-     * @param GameFieldController $_gameFieldController The GameFieldController for calculating alive states of all cells for each round.
-     * @param int $_numCycles Amount of rounds the game should be played.
+     * @param GameField $_gameField The GameField for retrieving alive states of all cells for each round.
+     * @param int $_cycle The current game cycle which is saved.
      */
-    public function createPng($_gameFieldController, $_numCycles)
+    public function createPng($_gameField, $_cycle)
     {
-        $numCycles = $_numCycles;
-        $gameFieldController = $_gameFieldController;
-        $x = $gameFieldController->getGameField()->getWidth();
-        $y = $gameFieldController->getGameField()->getHeight();
+        $gameField = $_gameField;
+        $x = $gameField->getWidth();
+        $y = $gameField->getHeight();
 
-        for($cycle = 0; $cycle<$numCycles; $cycle++)
-        { // Amount of cycles
-            $fieldPng = imagecreate($x*10,$y*10);
-            imagecolorallocate($fieldPng, 243, 243, 243);
-            imagesetthickness($fieldPng, 5);
+        $fieldPng = imagecreate($x*10,$y*10);
+        imagecolorallocate($fieldPng, 243, 243, 243);
+        imagesetthickness($fieldPng, 5);
 
-            for($i=0; $i<$y; $i++)
-            { // Make columns
-                for($j=0; $j<$x; $j++)
-                { // Make rows
-                    if($gameFieldController->getGameField()->getCellByCoords($j,$i)->isAlive() == true)
-                    {
-                        $x1 = $j * 10 - 2;
-                        $x2 = $x1 + 10 - 2;
-                        $y1 = $i * 10 - 2;
-                        $y2 = $y1 + 10 - 2;
-                        imagefilledrectangle($fieldPng, $x1, $y1, $x2, $y2, 25);
-                    }
+        for($i=0; $i<$y; $i++)
+        { // Make columns
+            for($j=0; $j<$x; $j++)
+            { // Make rows
+                if($gameField->getCellByCoords($j,$i)->isAlive() == true)
+                {
+                    $x1 = $j * 10 - 2;
+                    $x2 = $x1 + 10 - 2;
+                    $y1 = $i * 10 - 2;
+                    $y2 = $y1 + 10 - 2;
+                    imagefilledrectangle($fieldPng, $x1, $y1, $x2, $y2, 25);
                 }
             }
-            imagepng($fieldPng,__DIR__."/output/png/cycle".$cycle.".png");
-            imagedestroy($fieldPng);
-            $gameFieldController->run();
         }
+        imagepng($fieldPng,__DIR__."/../tmp/png/png".$_cycle.".png");
+        imagedestroy($fieldPng);
     }
 }

--- a/v1/lib/pngcreator.php
+++ b/v1/lib/pngcreator.php
@@ -13,27 +13,26 @@
 class pngCreator
 {
     /**
-     * Creates the png and saves it to lib/output/png.
+     * Creates the png and saves it to v1/tmp/png.
      *
-     * @param GameField $_gameField The GameField for retrieving alive states of all cells for each round.
-     * @param int $_cycle The current game cycle which is saved.
+     * @param GameField $_gameField The GameField for retrieving alive states of all cells.
+     * @param int $_cycle The number of current cycle for naming the png file.
      */
     public function createPng($_gameField, $_cycle)
     {
-        $gameField = $_gameField;
-        $x = $gameField->getWidth();
-        $y = $gameField->getHeight();
+        $x = $_gameField->getWidth();
+        $y = $_gameField->getHeight();
 
         $fieldPng = imagecreate($x*10,$y*10);
         imagecolorallocate($fieldPng, 243, 243, 243);
         imagesetthickness($fieldPng, 5);
 
-        for($i=0; $i<$y; $i++)
-        { // Make columns
-            for($j=0; $j<$x; $j++)
-            { // Make rows
-                if($gameField->getCellByCoords($j,$i)->isAlive() == true)
-                {
+        for ($i=0; $i<$y; $i++)
+        { // Draw rows
+            for ($j=0; $j<$x; $j++)
+            { // Draw columns
+                if($_gameField->getCellByCoords($j,$i)->isAlive() == true)
+                { // Draw a black rectangle it the cell is alive
                     $x1 = $j * 10 - 2;
                     $x2 = $x1 + 10 - 2;
                     $y1 = $i * 10 - 2;

--- a/v1/lib/pngcreator.php
+++ b/v1/lib/pngcreator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * @version 0.1
@@ -6,21 +7,17 @@
  * @author Max Späth <max.spaeth@cn-consult.eu>
  */
 
-require_once __DIR__.'/../baseoutput.php';
-
 /**
- * This class inherits from the BaseOutput class, so we need to implement the output() function here, which will print every game cycle the complete gamefield on a console.
+ * This class creates and saves the gamefield each round as a png file.
  */
-class ConsoleOutput extends BaseOutput
+class pngCreator
 {
     /**
-     * This function is extended from the baseoutput class.
-     * It prints the gamefield to the console for the number of cycles given.
-     *
+     * Creates the png and saves it to lib/output/png.
      * @param GameFieldController $_gameFieldController The GameFieldController for calculating alive states of all cells for each round.
      * @param int $_numCycles Amount of rounds the game should be played.
      */
-    public function output(GameFieldController $_gameFieldController, $_numCycles)
+    public function createPng($_gameFieldController, $_numCycles)
     {
         $numCycles = $_numCycles;
         $gameFieldController = $_gameFieldController;
@@ -29,17 +26,23 @@ class ConsoleOutput extends BaseOutput
 
         for ($cycle = 0; $cycle<$numCycles; $cycle++)
         { // Amount of cycles
+            $fieldPng = imagecreate($x*10,$y*10);
+            imagecolorallocate($fieldPng, 243, 243, 243);
+            imagesetthickness($fieldPng, 5);
+            
             for($i=0; $i<$y; $i++)
             { // Make columns
                 for($j=0; $j<$x; $j++)
                 { // Make rows
-                    if ($gameFieldController->getGameField()->getCellByCoords($j,$i)->isAlive()) echo "1";
-                    else echo "0";
+                    $x1 = $j*10-2;
+                    $x2 = $x1+10-2;
+                    $y1 = $i*10-2;
+                    $y2 = $y1+10-2;
+                    imagefilledrectangle($fieldPng , $x1 , $y1 , $x2 , $y2 , 25 );
                 }
-                echo "\n";
             }
-            echo "---------------------\n";
-
+            imagepng($fieldPng,__DIR__."/png/cycle".$numCycles.".png");
+            imagedestroy($fieldPng);
             $gameFieldController->run();
         }
     }


### PR DESCRIPTION
Added a pngoutput class as second output option.
It uses the pngcreator class to create and save the png each round.

Example for three played rounds with --type blinker:

![cycle0](https://cloud.githubusercontent.com/assets/8329841/13046390/bc651ac6-d3d8-11e5-9d0d-0e54d7a68f4e.png)
![cycle1](https://cloud.githubusercontent.com/assets/8329841/13046391/bc655dc4-d3d8-11e5-807f-eedd8f20774e.png)
![cycle2](https://cloud.githubusercontent.com/assets/8329841/13046392/bc67d072-d3d8-11e5-94eb-cc5b449f78d9.png)

You can call this output with --output Png as parameter.
The png's are saved to /lib/output/png/.

**Tests done**
- Run game with --output Png as parameter and checked the .png files (you can see them above).
