### PR TITLE
Merge feature/create-gif-output

### DIFF
--- a/v1/lib/output/gifoutput.php
+++ b/v1/lib/output/gifoutput.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * @version 0.1
+ * @copyright 2016 CN-Consult GmbH
+ * @author Max Späth <max.spaeth@cn-consult.eu>
+ */
+
+require_once __DIR__."/../pngcreator.php";
+require_once __DIR__."/../GifCreator.php";
+require_once __DIR__."/../baseoutput.php";
+
+/**
+ * This class inherits from the BaseOutput class, so we need to implement the output() function here, which will save the game cycles as a gif animation.
+ */
+class GifOutput extends BaseOutput
+{
+    /**
+     * This function is extended from the baseoutput class.
+     * It creates and saves the game cycles as a gif file to /v1/tmp/gif.
+     *
+     * @param GameFieldController $_gameFieldController The gamefieldcontroller which contains the gamefield.
+     * @param int $_numCycles The amount of rounds the game should be played.
+     */
+    public function output(GameFieldController $_gameFieldController, $_numCycles)
+    {
+        $pngCreator = new PngCreator;
+        $gifCreator = new GifCreator(0, 2, array(-1, -1, -1));
+
+        for ($cycle = 0; $cycle<$_numCycles; $cycle++)
+        { // Creates a png for each cycle and adds it to the gif frame.
+            $pngCreator->createPng($_gameFieldController->getGameField(),$cycle);
+            $gifCreator->addFrame(file_get_contents(__DIR__."/../../tmp/png/png".$cycle.".png"), 50);
+            unlink(__DIR__."/../../tmp/png/png".$cycle.".png");
+            $_gameFieldController->run();
+        }
+
+        file_put_contents(__DIR__."/../../tmp/gif/animation.gif", $gifCreator->getAnimation());
+    }
+}


### PR DESCRIPTION
Added a gifoutput class as third output option.
It uses the pngcreator class to create the png file of the gamefield each cycle and adds it to the gif animation.
The gif animation is saved to v1/tmp/gif/.

This output is called with the --output Gif parameter.

Example gif animation (glider with 20 cycles):

![animation](https://cloud.githubusercontent.com/assets/8329841/13048599/4a75e21a-d3e7-11e5-9b38-5d77e3b89c3d.gif)

**Tests done**
- Run game with --output Gif parameter success, the created animation you can view above.
