### PR TITLE
Merge feature/create-input-from-txt-as-plugin

### DIFF
--- a/v1/lib/baseinput.php
+++ b/v1/lib/baseinput.php
@@ -19,26 +19,39 @@ abstract class BaseInput
     protected $height;
 
     /**
-     * Class constructor
+     * Class constructor which creates the gamefield and then sets the active cells.
+     *
      * @param array $_config If a plugin needs specific values you can give an associative array as parameter which contains the necessary data.
      */
-    abstract public function __construct(array $_config = NULL);
+    public function __construct(array $_config = null)
+    {
+        $this->createGamefield();
+        $this->setCells();
+    }
 
     /**
-     * This function creates the gamefield.
+     * Creates the gamefield and calls setCells() to set cells alive.
      */
-    abstract protected function createGamefield();
+    public function createGamefield()
+    {
+        $this->gamefield = new GameField($this->width, $this->height);
+    }
 
     /**
-     * This function sets the cells alive for the first round.
+     * This function needs to be implemented in every plugin which extends from this class.
+     * This function sets cells alive.
      */
     abstract protected function setCells();
 
     /**
      * This function returns the gamefield.
+     *
      * @return GameField
      */
-    abstract public function getGameField();
+    public function getGameField()
+    {
+        return $this->gamefield;
+    }
 
 
 }

--- a/v1/lib/baseinput.php
+++ b/v1/lib/baseinput.php
@@ -20,6 +20,7 @@ abstract class BaseInput
 
     /**
      * Class constructor which creates the gamefield and then sets the active cells.
+     * This parent constructor MUST be called from every inherited class!
      *
      * @param array $_config If a plugin needs specific values you can give an associative array as parameter which contains the necessary data.
      */
@@ -30,7 +31,7 @@ abstract class BaseInput
     }
 
     /**
-     * Creates the gamefield and calls setCells() to set cells alive.
+     * Creates the gamefield.
      */
     public function createGamefield()
     {
@@ -38,15 +39,14 @@ abstract class BaseInput
     }
 
     /**
-     * This function needs to be implemented in every plugin which extends from this class.
-     * This function sets cells alive.
+     * The implemented function will set depending on their input the given cells alive.
      */
     abstract protected function setCells();
 
     /**
      * This function returns the gamefield.
      *
-     * @return GameField
+     * @return GameField The GameField created by the input plugin.
      */
     public function getGameField()
     {

--- a/v1/lib/baseinput.php
+++ b/v1/lib/baseinput.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * @version 0.1
+ * @copyright 2016 CN-Consult GmbH
+ * @author Max Späth <max.spaeth@cn-consult.eu>
+ */
+
+/**
+ * This abstract class is the base class for the input plugins.
+ * All input classes have to extend from this class.
+ */
+abstract class BaseInput
+{
+    protected $gamefield;
+    protected $gamefieldController;
+    protected $width;
+    protected $height;
+
+    /**
+     * Class constructor
+     * @param array $_config If a plugin needs specific values you can give an associative array as parameter which contains the necessary data.
+     */
+    abstract public function __construct(array $_config = NULL);
+
+    /**
+     * This function creates the gamefield.
+     */
+    abstract protected function createGamefield();
+
+    /**
+     * This function sets the cells alive for the first round.
+     */
+    abstract protected function setCells();
+
+    /**
+     * This function returns the gamefield.
+     * @return GameField
+     */
+    abstract public function getGameField();
+
+
+}

--- a/v1/lib/input/txtinput.php
+++ b/v1/lib/input/txtinput.php
@@ -10,20 +10,35 @@
 require_once __DIR__."/../baseinput.php";
 require_once __DIR__."/../gamefield.php";
 require_once __DIR__."/../gamefieldcontroller.php";
+
 /**
- * This class opens a txt file which contains the start gamefield and sets the necessary cells alive according to the gamefield of the txt file.
- * The path to the txt file is delivered in the $config array.
+ * This plugins reads a text file which contains the start gamefield of the GoL.
+ * The gamefield in the txt should look something like this:
+ *
+ * 00000000
+ * 00000000
+ * 00010000
+ * 00010000
+ * 00010000
+ *
+ * 0 = dead cells
+ * 1 = living cells
+ *
+ * To use this plugin, you have to call the runGame.php with --input Txt and --filePath 'Path to txt file' and also
+ * specify the number of cycles with --numCycles and the output with --output.
+ * Example:
+ * runGame.php --input Txt --filepath D:\gamefield.txt --numCycles 10 --output Console
  */
 class TxtInput extends BaseInput
 {
     private $file;
 
     /**
-     * The constructor sets the the opens the txt file and calls the parent constructor to create the gamefield and set the cells.
+     * The constructor opens the txt file and calls the parent constructor to create the gamefield and set the cells.
      *
-     * @param array|NULL $_config Contains the path to the txt file with the gamefield (Required in this case).
+     * @param array|null $_config Config array which should contain in this context at least the filepath to the txt file, which we need for creating a GameField.
      */
-    public function __construct(array $_config = NULL)
+    public function __construct(array $_config = null)
     {
         if(isset($_config))
         {

--- a/v1/lib/input/txtinput.php
+++ b/v1/lib/input/txtinput.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @file
+ * @version 0.1
+ * @copyright 2016 CN-Consult GmbH
+ * @author Max Späth <max.spaeth@cn-consult.eu>
+ */
+
+require_once __DIR__."/../baseinput.php";
+require_once __DIR__."/../gamefield.php";
+require_once __DIR__."/../gamefieldcontroller.php";
+/**
+ * This class opens a txt file which contains the start gamefield and sets the necessary cells alive.
+ * The path to the txt file is saved in the $config array.
+ */
+class TxtInput extends BaseInput
+{
+    private $file;
+
+    /**
+     * The constructor sets the config value which contains the filepath.
+     * @param array|NULL $_config Contains the path to the txt file with the gamefield (Required).
+     */
+    public function __construct(array $_config = NULL)
+    {
+        if(isset($_config))
+        {
+            $this->file=$_config['filePath'];
+            $linecount = 0;
+            $handle = fopen($this->file, "r");
+            while(!feof($handle))
+            {
+                $line = fgets($handle);
+                if(empty($this->width)) $this->width = strlen($line)-2;
+                $linecount++;
+            }
+            $this->height = $linecount-1;
+            fclose($handle);
+        }
+        else die("Error can't find txt file, please use --filepath 'path to file'");
+        $this->createGamefield();
+    }
+
+
+    /**
+     * Creates the gamefield and calls setCells() to set the specified cells from the txt file alive.
+     */
+    public function createGamefield()
+    {
+        $this->gamefield = new GameField($this->width, $this->height);
+        $this->setCells();
+    }
+
+    /**
+     * Opens the txt file and sets every cell alive which is set to true(1).
+     */
+    public function setCells()
+    {
+        $handle = fopen($this->file, "r");
+
+        for ($y=0; $y<$this->height; $y++)
+        {
+            $line = fgets($handle);
+            for ($x=0; $x<$this->width; $x++)
+            {
+                if ($line[$x] == "1") $this->gamefield->getCellByCoords($x,$y)->life();
+            }
+        }
+
+        fclose($handle);
+    }
+
+    /**
+     * Returns the gamefield.
+     * @return GameField The gamefield.
+     */
+    public function getGameField()
+    {
+        return $this->gamefield;
+    }
+
+}
+
+

--- a/v1/lib/input/txtinput.php
+++ b/v1/lib/input/txtinput.php
@@ -11,16 +11,17 @@ require_once __DIR__."/../baseinput.php";
 require_once __DIR__."/../gamefield.php";
 require_once __DIR__."/../gamefieldcontroller.php";
 /**
- * This class opens a txt file which contains the start gamefield and sets the necessary cells alive.
- * The path to the txt file is saved in the $config array.
+ * This class opens a txt file which contains the start gamefield and sets the necessary cells alive according to the gamefield of the txt file.
+ * The path to the txt file is delivered in the $config array.
  */
 class TxtInput extends BaseInput
 {
     private $file;
 
     /**
-     * The constructor sets the config value which contains the filepath.
-     * @param array|NULL $_config Contains the path to the txt file with the gamefield (Required).
+     * The constructor sets the the opens the txt file and calls the parent constructor to create the gamefield and set the cells.
+     *
+     * @param array|NULL $_config Contains the path to the txt file with the gamefield (Required in this case).
      */
     public function __construct(array $_config = NULL)
     {
@@ -37,23 +38,14 @@ class TxtInput extends BaseInput
             }
             $this->height = $linecount-1;
             fclose($handle);
+
+            parent::__construct($_config);
         }
         else die("Error can't find txt file, please use --filepath 'path to file'");
-        $this->createGamefield();
-    }
-
-
-    /**
-     * Creates the gamefield and calls setCells() to set the specified cells from the txt file alive.
-     */
-    public function createGamefield()
-    {
-        $this->gamefield = new GameField($this->width, $this->height);
-        $this->setCells();
     }
 
     /**
-     * Opens the txt file and sets every cell alive which is set to true(1).
+     * Opens the txt file and sets every cell alive which is set to true(1) in the file.
      */
     public function setCells()
     {
@@ -69,15 +61,6 @@ class TxtInput extends BaseInput
         }
 
         fclose($handle);
-    }
-
-    /**
-     * Returns the gamefield.
-     * @return GameField The gamefield.
-     */
-    public function getGameField()
-    {
-        return $this->gamefield;
     }
 
 }

--- a/v1/runGame.php
+++ b/v1/runGame.php
@@ -19,31 +19,51 @@ $options = new Getopt(array(
     array('f','filepath',Getopt::OPTIONAL_ARGUMENT,'Path to txt file(only required if txt is choosen as input'),
     array('o','output',Getopt::REQUIRED_ARGUMENT,'Output in console, as png or gif'),
     array('c','numCycles',Getopt::REQUIRED_ARGUMENT, 'Number of rounds the game should play 1-*'),
-    array('H', 'help', Getopt::NO_ARGUMENT)
+    array('h', 'help', Getopt::NO_ARGUMENT)
 
 ));
 
 $options->parse();
 
-if ($options->getOption('input'))
+if ($options->getOption("help"))
 {
-    if ($options->getOption("filepath")) $config = array('filePath' => $options->getOption('filepath'));
-    $inputClass = $options->getOption("input")."Input";
-    $input = new $inputClass($config);
-
-    if ($options->getOption("output"))
+    $options->showHelp();
+}
+else
+{
+    if ($options->getOption('input'))
     {
+        if ($options->getOption("filepath")) $config = array('filePath' => $options->getOption('filepath'));
+        $inputClass = $options->getOption("input")."Input";
+        $input = new $inputClass($config);
+
         $outputClass = $options->getOption("output")."Output";
         $numCycles = $options->getOption('numCycles');
 
         if ($options->getOption("numCycles"))
         {
-            $gameFieldController = new GameFieldController($input->getGameField());
-            $output = new $outputClass();
-            $output->output($gameFieldController, $numCycles);
+            if ($options->getOption("output"))
+            {
+                $gameFieldController = new GameFieldController($input->getGameField());
+                $output = new $outputClass();
+                $output->output($gameFieldController, $numCycles);
+            }
+            else
+            {
+                $options->showHelp();
+                die("Please specify an output mode, view help for more information!");
+            }
         }
-        else die("Please specify a number of cycles the game should be played");
+        else
+        {
+            $options->showHelp();
+            die("Please specify a number of cycles the game should be played, view help for more information!");
+        }
     }
-    else die("Please specify an output mode");
+    else
+    {
+        $options->showHelp();
+        die("Please specify input mode, view help for more information!");
+    }
 }
-else die("Wrong input");
+

--- a/v1/runGame.php
+++ b/v1/runGame.php
@@ -11,83 +11,39 @@ require_once "lib/gamefield.php";
 include_once("lib/external/vendor/autoload.php");
 
 foreach (glob('lib/output/*.php') as $file) include( $file );
+foreach (glob('lib/input/*.php') as $file) include( $file );
 
 use Ulrichsg\Getopt;
 $options = new Getopt(array(
-            array('o','output',Getopt::REQUIRED_ARGUMENT,'Output in console, as png or gif'),
-            array('w','width',Getopt::REQUIRED_ARGUMENT,'Length of x-axis of the gamefield 1-*'),
-            array('h','height',Getopt::REQUIRED_ARGUMENT,'Length of the y-axis of the gamefield 1-*'),
-            array('c','numCycles',Getopt::REQUIRED_ARGUMENT, 'Number of rounds the game should play 1-*'),
-            array('t','type',Getopt::REQUIRED_ARGUMENT, 'Figure that should be set, blinker, glider, or lws'),
-            array('H', 'help', Getopt::NO_ARGUMENT)
+    array('i','input',Getopt::REQUIRED_ARGUMENT,'Input type (for now only txt is implemented'),
+    array('f','filepath',Getopt::OPTIONAL_ARGUMENT,'Path to txt file(only required if txt is choosen as input'),
+    array('o','output',Getopt::REQUIRED_ARGUMENT,'Output in console, as png or gif'),
+    array('c','numCycles',Getopt::REQUIRED_ARGUMENT, 'Number of rounds the game should play 1-*'),
+    array('H', 'help', Getopt::NO_ARGUMENT)
 
 ));
 
 $options->parse();
 
-if ($options->getOption('width')) $x = $options->getOption('h');
-else echo "Argument --width is missing\n";
-
-if ($options->getOption('height')) $y = $options->getOption('h');
-else echo "Argument --height is missing\n";
-
-if (isset($x) && isset($y))
+if ($options->getOption('input'))
 {
-    $gameField = new GameField($x,$y);
+    if ($options->getOption("filepath")) $config = array('filePath' => $options->getOption('filepath'));
+    $inputClass = $options->getOption("input")."Input";
+    $input = new $inputClass($config);
 
-    if($options->getOption('type')) {
+    if ($options->getOption("output"))
+    {
+        $outputClass = $options->getOption("output")."Output";
+        $numCycles = $options->getOption('numCycles');
 
-        switch ($options->getOption('type'))
+        if ($options->getOption("numCycles"))
         {
-            case "blinker":
-                $gameField->getCellByCoords(3, 2)->life();
-                $gameField->getCellByCoords(3, 3)->life();
-                $gameField->getCellByCoords(3, 4)->life();
-                break;
-
-            case "glider":
-                $gameField->getCellByCoords(2, 1)->life();
-                $gameField->getCellByCoords(3, 2)->life();
-                $gameField->getCellByCoords(3, 3)->life();
-                $gameField->getCellByCoords(2, 3)->life();
-                $gameField->getCellByCoords(1, 3)->life();
-                break;
-
-            case "lws":
-                $gameField->getCellByCoords(1, 5)->life();
-                $gameField->getCellByCoords(2, 4)->life();
-                $gameField->getCellByCoords(3, 4)->life();
-                $gameField->getCellByCoords(4, 4)->life();
-                $gameField->getCellByCoords(5, 4)->life();
-                $gameField->getCellByCoords(5, 5)->life();
-                $gameField->getCellByCoords(5, 6)->life();
-                $gameField->getCellByCoords(4, 7)->life();
-                $gameField->getCellByCoords(1, 7)->life();
-                break;
-
-            default:
-                echo "Wrong type!\n";
+            $gameFieldController = new GameFieldController($input->getGameField());
+            $output = new $outputClass();
+            $output->output($gameFieldController, $numCycles);
         }
-
-        if($options->getOption('output'))
-        {
-            $outputClass = $options->getOption("output")."Output";
-            if($options->getOption('numCycles'))
-            {
-                $numCycles = $options->getOption('numCycles');
-
-                $gameFieldController = new GameFieldController($gameField);
-                $output = new $outputClass();
-                $output->output($gameFieldController, $numCycles);
-            }
-            else echo "Missing --numCycles argument\n";
-        }
-        else echo "Missing --output argument\n";
+        else die("Please specify a number of cycles the game should be played");
     }
-    else echo "Missing --type argument\n";
+    else die("Please specify an output mode");
 }
-
-if($options->getOption('help'))
-{
-    $options->showHelp();
-}
+else die("Wrong input");

--- a/v1/runGame.php
+++ b/v1/runGame.php
@@ -15,14 +15,15 @@ foreach (glob('lib/input/*.php') as $file) include( $file );
 
 use Ulrichsg\Getopt;
 $options = new Getopt(array(
-    array('i','input',Getopt::REQUIRED_ARGUMENT,'Input type (for now only txt is implemented'),
+    array('i','input',Getopt::REQUIRED_ARGUMENT,'Specifys how the start gamefield should be read, "txt" for reading from txt file' ),
     array('f','filepath',Getopt::OPTIONAL_ARGUMENT,'Path to txt file(only required if txt is choosen as input'),
-    array('o','output',Getopt::REQUIRED_ARGUMENT,'Output in console, as png or gif'),
+    array('o','output',Getopt::REQUIRED_ARGUMENT,'"console" for console output, "png" for output as png file, "gif" for output as .gif file.'),
     array('c','numCycles',Getopt::REQUIRED_ARGUMENT, 'Number of rounds the game should play 1-*'),
     array('h', 'help', Getopt::NO_ARGUMENT)
 
 ));
 
+echo "test";
 $options->parse();
 
 if ($options->getOption("help"))
@@ -38,10 +39,10 @@ else
         $input = new $inputClass($config);
 
         $outputClass = $options->getOption("output")."Output";
-        $numCycles = $options->getOption('numCycles');
 
         if ($options->getOption("numCycles"))
         {
+            $numCycles = $options->getOption('numCycles');
             if ($options->getOption("output"))
             {
                 $gameFieldController = new GameFieldController($input->getGameField());


### PR DESCRIPTION
You now have to specify an --input parameter for choosing the input mode.
The first plugin i implemented now is the txt plugin.
To use it, you also have to specify a path with --filepath which contains a txt file with the starting gamefield for example like this:

![txtprev](https://cloud.githubusercontent.com/assets/8329841/13053690/17512786-d406-11e5-9790-32abe45b3440.JPG)

The "0" are dead cells and the "1" living cells.

The game is now called with the following parameters for example:

php rungame.php --input txt --filepath D:\testfield.txt --output Console --numCycles 3

This will do the following:
- Using txt mode as input.
- Reading the file D:\textfield.txt which contains the starting field.
- Outputs it into the console.
- Plays 3 rounds.

For more help run the game with --help parameter.

**Tests done**
- Create example txt file and print the output to console
