### PR TITLE
Merge feature/create-console-input-plugin

### DIFF
--- a/v1/lib/baseinput.php
+++ b/v1/lib/baseinput.php
@@ -14,7 +14,6 @@
 abstract class BaseInput
 {
     protected $gamefield;
-    protected $gamefieldController;
     protected $width;
     protected $height;
 

--- a/v1/lib/input/consoleinput.php
+++ b/v1/lib/input/consoleinput.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @file
+ * @version 0.1
+ * @copyright 2016 CN-Consult GmbH
+ * @author Max Späth <max.spaeth@cn-consult.eu>
+ */
+
+require_once __DIR__."/../baseinput.php";
+require_once __DIR__."/../gamefield.php";
+
+/**
+ * This plugin takes input from the console to specify the width/height of the gamefield and which sets should be set alive.
+ * To use it, just set 'console' as --input parameter and set the --numCycles (Number of rounds should be played and the --output (console, png or gif).
+ * Example use:
+ *
+ * runGame.php --input console --numCycles 10 --output console
+ */
+class ConsoleInput extends BaseInput
+{
+
+    /**
+     * The constructor asks for the width and height of the gamefield to create it in the parent constructor.
+     *
+     * @param array|null $_config No config is needed here.
+     */
+    public function __construct(array $_config = null)
+    {
+        echo "Please enter the width of the gamefield\n";
+        $this->width = stream_get_line(STDIN, 1024, PHP_EOL);
+        echo "Please enter the height of the gamefield\n";
+        $this->height = stream_get_line(STDIN, 1024, PHP_EOL);
+
+        parent::__construct($_config);
+    }
+
+    /**
+     * This function asks for the number and x/y coordinates of the cells that should be set alive.
+     */
+    protected function setCells()
+    {
+        echo "How many cells do you want to set?\n";
+        $numCells = stream_get_line(STDIN, 1024, PHP_EOL);
+
+        for ($i = 0; $i < $numCells; $i++)
+        {
+            echo "Please enter the x coordinate of the cell\n";
+            $x = stream_get_line(STDIN, 1024, PHP_EOL);
+            echo "Please enter the y coordinate of the cell\n";
+            $y = stream_get_line(STDIN, 1024, PHP_EOL);
+
+            $this->getGameField()->getCellByCoords($x,$y)->life();
+            echo "Cell ".$x."|".$y." set alive\n";
+        }
+    }
+}

--- a/v1/lib/input/consoleinput.php
+++ b/v1/lib/input/consoleinput.php
@@ -10,11 +10,8 @@ require_once __DIR__."/../baseinput.php";
 require_once __DIR__."/../gamefield.php";
 
 /**
- * This plugin takes input from the console to specify the width/height of the gamefield and which sets should be set alive.
- * To use it, just set 'console' as --input parameter and set the --numCycles (Number of rounds should be played and the --output (console, png or gif).
- * Example use:
- *
- * runGame.php --input console --numCycles 10 --output console
+ * This plugin asks the user over the console to specify the width/height of the gamefield and which cells sets should be set alive.
+ * To use it, just set 'console' as --input parameter.
  */
 class ConsoleInput extends BaseInput
 {

--- a/v1/lib/input/txtinput.php
+++ b/v1/lib/input/txtinput.php
@@ -9,7 +9,6 @@
 
 require_once __DIR__."/../baseinput.php";
 require_once __DIR__."/../gamefield.php";
-require_once __DIR__."/../gamefieldcontroller.php";
 
 /**
  * This plugins reads a text file which contains the start gamefield of the GoL.

--- a/v1/runGame.php
+++ b/v1/runGame.php
@@ -33,8 +33,9 @@ else
 {
     if ($options->getOption('input'))
     {
-        if ($options->getOption("filepath")) $config = array('filePath' => $options->getOption('filepath'));
-        else $config = null;
+        $config = array();
+        if ($options->getOption("filepath")) $config['filePath'] = $options->getOption('filepath');
+
         $inputClass = $options->getOption("input")."Input";
         $input = new $inputClass($config);
 

--- a/v1/runGame.php
+++ b/v1/runGame.php
@@ -23,7 +23,6 @@ $options = new Getopt(array(
 
 ));
 
-echo "test";
 $options->parse();
 
 if ($options->getOption("help"))
@@ -35,6 +34,7 @@ else
     if ($options->getOption('input'))
     {
         if ($options->getOption("filepath")) $config = array('filePath' => $options->getOption('filepath'));
+        else $config = null;
         $inputClass = $options->getOption("input")."Input";
         $input = new $inputClass($config);
 


### PR DESCRIPTION
Implement console input plugin.
You now can specify the width and height and the cells that should be set alive through the console.

To use it, run the game with the --input console parameter.
You don't have to specify --filepath now, only --input --numCycles --output.

Example:
php runGame.php --input console --numCycles 3 --output console
- This will run the game with console input, playing three rounds and printing each round to the console.

Screenshot:

![consoleinput](https://cloud.githubusercontent.com/assets/8329841/13141604/853bae18-d638-11e5-9470-f2b0c46f0cab.JPG)

**Tests done**
- Run the game with the --input console parameter (View screenshot above)
